### PR TITLE
Fix parsing of the 'required' constraint

### DIFF
--- a/services/schema.service.ts
+++ b/services/schema.service.ts
@@ -142,7 +142,7 @@ export class SchemaService {
 
     private static isRequiredField(field: Field): boolean {
         if (typeof field === 'object') {
-            return field.required;
+            return !!field.required;
         } else {
             return false;
         }

--- a/services/schema.service.ts
+++ b/services/schema.service.ts
@@ -142,7 +142,7 @@ export class SchemaService {
 
     private static isRequiredField(field: Field): boolean {
         if (typeof field === 'object') {
-            return 'constraints' in field && 'required' in field.constraints;
+            return field.required;
         } else {
             return false;
         }


### PR DESCRIPTION
Fixed issue where the constraint `required: false` on a field's schema was interpreted as `required: true`.

 Use the library datatable `Field.required` instead of our own parsing.