### PR TITLE
[ISK-16] Record edit datetime field format

### DIFF
--- a/utils/consts.ts
+++ b/utils/consts.ts
@@ -14,4 +14,6 @@ export let ISO_ANGULAR_DATE_FORMAT = 'yyyy-MM-dd';
 
 export let ISO_MOMENT_DATE_FORMAT = 'YYYY-MM-DD';
 
+export let ISO_MOMENT_DATE_TIME_FORMAT = 'YYYY-MM-DDTHH:mm:ss';
+
 export let AMBIGUOUS_DATE_PATTERN: RegExp = /^(\d{1,2})[-,\/](\d{1,2})[-,\/](\d{4})$/;

--- a/utils/functions.ts
+++ b/utils/functions.ts
@@ -1,4 +1,9 @@
-import { ANY_ANGULAR_DATE_FORMAT, ANY_MOMENT_DATE_FORMAT, ISO_ANGULAR_DATE_FORMAT, ISO_MOMENT_DATE_FORMAT } from './consts';
+import {
+    ANY_ANGULAR_DATE_FORMAT,
+    ANY_MOMENT_DATE_FORMAT,
+    ISO_ANGULAR_DATE_FORMAT,
+    ISO_MOMENT_DATE_FORMAT, ISO_MOMENT_DATE_TIME_FORMAT
+} from './consts';
 
 import { APIError, User } from '../interfaces/api.interfaces';
 
@@ -61,4 +66,12 @@ export function formatAPIError(error: APIError): object {
 
 export function formatUserFullName(user: User): string {
     return `${user.first_name} ${user.last_name}`.trim() || `${user.username}`.trim();
+}
+
+export function findDateTimeFormat(pythonDateFormat: string ) {
+    if (!pythonDateFormat || pythonDateFormat === 'any') {
+        return [ANY_MOMENT_DATE_FORMAT, ISO_MOMENT_DATE_TIME_FORMAT];
+    } else if (pythonDateFormat === 'default') {
+        return [ISO_MOMENT_DATE_FORMAT, ISO_MOMENT_DATE_TIME_FORMAT];
+    }
 }

--- a/utils/functions.ts
+++ b/utils/functions.ts
@@ -2,7 +2,8 @@ import {
     ANY_ANGULAR_DATE_FORMAT,
     ANY_MOMENT_DATE_FORMAT,
     ISO_ANGULAR_DATE_FORMAT,
-    ISO_MOMENT_DATE_FORMAT, ISO_MOMENT_DATE_TIME_FORMAT
+    ISO_MOMENT_DATE_FORMAT,
+    ISO_MOMENT_DATE_TIME_FORMAT
 } from './consts';
 
 import { APIError, User } from '../interfaces/api.interfaces';


### PR DESCRIPTION
Allow record edit form and table to accept dates in DD/MM/YYYY and YYYY-MM-DDTHH:mm:s format and convert to YYYY-MM-DDTHH:mm:s on save

YT Ticket: https://youtrack.gaiaresources.com.au/youtrack/issue/ISK-16/193-Editing-Reason-for-Invalidation-field-in-Records-Table-alters-First-Date